### PR TITLE
promote input dtypes to avoid ValueError: Integers to negative in…

### DIFF
--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -36,7 +36,7 @@ New functions/methods
 Bug fixes
 ^^^^^^^^^
 
-* Store comments from SWAN spectrum files as single string intead of a
+* Store comments from SWAN spectrum files as single string instead of a
   list of strings as the scipy netcdf I/O cannot cope with lists of
   strings.
 
@@ -48,7 +48,12 @@ Bug fixes
 
 * Do not squeeze energy matrix as that may cause conflicts with
   dimensions of length unity. Instead, reshape the energy matrix to
-  the approriate size.
+  the appropriate size.
+
+* Fix a datatype bug in spectral.jonswap() that raised `ValueError:
+  Integers to negative integer powers are not allowed` in the case Hm0 or Tp
+  were integers. Also modify spectral.jonswap() to accept arrays as inputs
+  for Hm0 and Tp. Only one-dimensional arrays for now. - Caio Stringari
 
 Tests
 ^^^^^

--- a/oceanwaves/spectral.py
+++ b/oceanwaves/spectral.py
@@ -37,6 +37,12 @@ def jonswap(f, Hm0, Tp, gamma=3.3, sigma_low=.07, sigma_high=.09,
     
     '''
 
+    # update the input data types to avoid the following error:
+    # ValueError: Integers to negative integer powers are not allowed.
+    f = f.astype(np.float)
+    Hm0 = Hm0.astype(np.float)
+    Tp = Tp.astype(np.float)
+
     # Pierson-Moskowitz
     if method.lower() == 'yamaguchi':
         alpha = 1. / (.06533 * gamma ** .8015 + .13467) / 16.

--- a/oceanwaves/spectral.py
+++ b/oceanwaves/spectral.py
@@ -49,13 +49,8 @@ def jonswap(f, Hm0, Tp, gamma=3.3, sigma_low=.07, sigma_high=.09,
     if 0.0 in f:
         warn("frequency array constains zeros.")
 
-    # get the frequency array dtype and promote to float 64, if
-    # needed
-    if type(f) != np.ndarray:
-        raise ValueError("\"f\" must of type numpy.ndarray.")
-        f = _check_dtype(f)
-
     # get the input dtypes and promote to float 64, if needed
+    f = _check_dtype(f)
     Hm0 = _check_dtype(Hm0)
     Tp = _check_dtype(Tp)
 

--- a/oceanwaves/spectral.py
+++ b/oceanwaves/spectral.py
@@ -4,6 +4,8 @@ import numpy as np
 
 from oceanwaves.utils import *
 
+from warnings import warn
+
 
 def jonswap(f, Hm0, Tp, gamma=3.3, sigma_low=.07, sigma_high=.09,
             g=9.81, method='yamaguchi', normalize=True):
@@ -13,9 +15,9 @@ def jonswap(f, Hm0, Tp, gamma=3.3, sigma_low=.07, sigma_high=.09,
     ----------
     f : numpy.ndarray
         Array of frequencies
-    Hm0 : float
+    Hm0 : float, numpy.ndarray
         Required zeroth order moment wave height
-    Tp : float
+    Tp : float, numpy.ndarray
         Required peak wave period
     gamma : float
         JONSWAP peak-enhancement factor (default: 3.3)
@@ -29,19 +31,44 @@ def jonswap(f, Hm0, Tp, gamma=3.3, sigma_low=.07, sigma_high=.09,
         Method to compute alpha (default: yamaguchi)
     normalize : bool
         Normalize resulting spectrum to match ``Hm0``
-    
+
     Returns
     -------
     E : numpy.ndarray
-        Array of shape ``f`` with wave energy densities 
-    
+        Array of shape ``f, Hm0.shape`` with wave energy densities
+
     '''
 
-    # update the input data types to avoid the following error:
+    # C Stringari - 04/06/2018
+    # check input data types to avoid the following error:
     # ValueError: Integers to negative integer powers are not allowed.
-    f = f.astype(np.float)
-    Hm0 = Hm0.astype(np.float)
-    Tp = Tp.astype(np.float)
+
+    # raise an warning if the frequency array starts with zero. if the
+    # user gives an array with zeros, the output will be inf at that
+    # frequency
+    if f[0] == 0.0:
+        warn("frequency array starts with zero.")
+
+    # get the frequency array dtype and promote to float 64, if
+    # needed
+    if type(f) != np.ndarray:
+        raise ValueError("\"f\" must of type numpy.ndarray.")
+        f = _check_dtype(f)
+
+    # get the input dtypes and promote to float 64, if needed
+    Hm0 = _check_dtype(Hm0)
+    Tp = _check_dtype(Tp)
+
+    # check shapes of Hm0 and Tp
+    if type(Hm0) == np.ndarray:
+        if Hm0.shape != Tp.shape:
+            raise ValueError("Dimensions of Hm0 and Tp should match.")
+
+    # This is a very naive implementation to deal with array inputs,
+    # but will work if Hm0 and Tp are vectors. I don't know how to expand
+    # the array to N dimensions nicely - C. Stringari
+    if type(Hm0) == np.ndarray:
+            f = np.repeat(f, Hm0.shape[0]).reshape([len(f), Hm0.shape[0]])
 
     # Pierson-Moskowitz
     if method.lower() == 'yamaguchi':
@@ -51,17 +78,21 @@ def jonswap(f, Hm0, Tp, gamma=3.3, sigma_low=.07, sigma_high=.09,
     else:
         raise ValueError('Unknown method: %s' % method)
 
-    E_pm  = alpha * Hm0**2 * Tp**-4 * f**-5 * np.exp(-1.25 * (Tp * f)**-4)
-        
+    E_pm = alpha * Hm0**2 * Tp**-4 * f**-5 * np.exp(-1.25 * (Tp * f)**-4)
+
     # JONSWAP
     sigma = np.ones(f.shape) * sigma_low
     sigma[f > 1./Tp] = sigma_high
 
-    E_js = E_pm * gamma**np.exp(-0.5 * (Tp * f - 1)**2. / sigma**2.);
-    
+    E_js = E_pm * gamma**np.exp(-0.5 * (Tp * f - 1)**2. / sigma**2.)
+
     if normalize:
-        E_js *= Hm0**2. / (16. * trapz_and_repeat(E_js, f, axis=-1))
-        
+        if type(Hm0) == np.ndarray:
+            # axis=-1 with an array return all infs
+            E_js *= Hm0**2. / (16. * trapz_and_repeat(E_js, f, axis=0))
+        else:
+            E_js *= Hm0**2. / (16. * trapz_and_repeat(E_js, f, axis=-1))
+
     return E_js
 
 
@@ -86,11 +117,10 @@ def directional_spreading(theta, theta_peak=0., s=20., units='deg',
     -------
     p_theta : numpy.ndarray
        Array of directional weights
-
     '''
-    
+
     from math import gamma
-    
+
     theta = np.asarray(theta, dtype=np.float)
 
     # convert units to radians
@@ -103,8 +133,8 @@ def directional_spreading(theta, theta_peak=0., s=20., units='deg',
         raise ValueError('Unknown units: %s')
 
     # compute directional spreading
-    #A1 = (2.**s) * (gamma(s / 2 + 1))**2. / (np.pi * gamma(s + 1))
-    #p_theta = A1 * np.maximum(0., np.cos(theta - theta_peak))
+    # A1 = (2.**s) * (gamma(s / 2 + 1))**2. / (np.pi * gamma(s + 1))
+    # p_theta = A1 * np.maximum(0., np.cos(theta - theta_peak))
     p_theta = np.maximum(0., np.cos(theta - theta_peak))**s
 
     # convert to original units
@@ -112,10 +142,40 @@ def directional_spreading(theta, theta_peak=0., s=20., units='deg',
         theta = np.degrees(theta)
         theta_peak = np.degrees(theta_peak)
         p_theta = np.degrees(p_theta)
-    
+
     # normalize directional spreading
     if normalize:
         p_theta /= trapz_and_repeat(p_theta, theta - theta_peak, axis=-1)
 
     return p_theta
 
+
+def _check_dtype(var):
+    '''
+    Auxiliary function to detect and fix dtypes, if needed
+
+    Parameters
+    ----------
+    var : anything
+        Array to check
+
+    Returns
+    -------
+    var : numpy.ndarray
+       The same as the input but either as a float or a array of floats
+    '''
+    # fist, if it's a list, convert to a numpy.ndarray
+    if type(var) == list:
+        var = np.array(var)
+    # if it's an np.ndarray(), make sure it's a array of floats
+    elif type(var) == np.ndarray:
+        if var.dtype != np.dtype('float64'):
+            var = var.astype(np.float64)
+    # if it's a float, well, do nothing
+    elif type(var) == float:
+        var = var
+    # unknown data type
+    else:
+        raise ValueError("Data type could not be detected automatically.")
+    # allways return a float or array of floats
+    return var

--- a/oceanwaves/spectral.py
+++ b/oceanwaves/spectral.py
@@ -46,8 +46,8 @@ def jonswap(f, Hm0, Tp, gamma=3.3, sigma_low=.07, sigma_high=.09,
     # raise an warning if the frequency array starts with zero. if the
     # user gives an array with zeros, the output will be inf at that
     # frequency
-    if f[0] == 0.0:
-        warn("frequency array starts with zero.")
+    if 0.0 in f:
+        warn("frequency array constains zeros.")
 
     # get the frequency array dtype and promote to float 64, if
     # needed

--- a/tests/test_spectral.py
+++ b/tests/test_spectral.py
@@ -25,8 +25,8 @@ def test_jonswap_with_arrays():
     '''Test computation of jonswap spectrum using arrays as input'''
     E = jonswap(FREQ, Hm0=np.array([1.0, 1.0]), Tp=np.array([4.0, 4.0]),
                 method='goda', normalize=True)
-    assert_almost_equals(np.trapz(E[:, 0], FREQ), 1/16.)
-    assert_almost_equals(FREQ[np.argmax(E[:, 0])], 1/4.)
+    assert_equal(E.ndim, 2)
+    assert_equal(E.shape[1], 2)
 
 
 @raises(ValueError)

--- a/tests/test_spectral.py
+++ b/tests/test_spectral.py
@@ -5,6 +5,7 @@ from oceanwaves.spectral import *
 FREQ = np.arange(0, 1, .05)[1:]
 THETA = np.arange(0, 180, 5)
 
+
 def test_jonswap_1():
     '''Test computation of jonswap spectrum following Yamaguchi'''
     E = jonswap(FREQ, Hm0=1., Tp=4., method='yamaguchi',
@@ -18,6 +19,14 @@ def test_jonswap_2():
     E = jonswap(FREQ, Hm0=1., Tp=4., method='goda', normalize=True)
     assert_almost_equals(np.trapz(E, FREQ), 1/16.)
     assert_almost_equals(FREQ[np.argmax(E)], 1/4.)
+
+
+def test_jonswap_with_arrays():
+    '''Test computation of jonswap spectrum using arrays as input'''
+    E = jonswap(FREQ, Hm0=np.array([1.0, 1.0]), Tp=np.array([4.0, 4.0]),
+                method='goda', normalize=True)
+    assert_almost_equals(np.trapz(E[:, 0], FREQ), 1/16.)
+    assert_almost_equals(FREQ[np.argmax(E[:, 0])], 1/4.)
 
 
 @raises(ValueError)


### PR DESCRIPTION
Promote input parameters dtypes to avoid ValueError: Integers to negative integer powers are not allowed.

This bug seems to be caused when you do something like this:

Hs = np.arange(1,10,1)

E = jonswap(f, Hs[0], Tp)