### PR TITLE
Updated parse_data to deal with more than 200 directional bins aand zeros

### DIFF
--- a/oceanwaves/swan.py
+++ b/oceanwaves/swan.py
@@ -501,8 +501,17 @@ class SwanSpcReader:
         else:
             f = 1.
 
-        n = len(self.frequencies)
-        q = np.asarray(self.lines.read_blockbody(n)) * f
+        if len(self.directions)<= 200:
+            n = len(self.frequencies)
+            q = np.asarray(self.lines.read_blockbody(n), dtype=np.float64) * f
+        else:
+            n = int(np.ceil(len(self.directions)/200))*len(self.frequencies)
+            temp = self.lines.read_blockbody(n)
+            temp_q=[]
+            for ii in range(len(self.frequencies)):
+                temp_q.append(temp[2*ii]+temp[2*ii+1])
+            q = np.asarray(temp_q, dtype=np.float64) * f
+            
         if self.stationary:
             self.quantities.append(q)
         else:


### PR DESCRIPTION
Updated parse_data to deal with more than 200 directional bins as well as spectra with all zeros

Apparently a maximum of 200 directional bins is written by SWAN to one line (this is hardcoded somewhere, not part of a swan input/use settings. With more than 200 bins, the data is written in multiple lines. Code changes allows for this.

Furthermore, if for some reason all data is zero (or more specifically all integer), the np.asarray makes and integer array, which does not allow multiplication with the floating value of factor f. Changed np.asarray to also hardcode float64.
